### PR TITLE
strip checkdigits from fo.xml

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/export/FOXML.scala
+++ b/src/main/scala/nl/knaw/dans/easy/export/FOXML.scala
@@ -34,6 +34,8 @@ object FOXML {
     override def transform(n: Node): NodeSeq = n match {
       case Elem("foxml", "datastream", _, _, _*) if !plainCopy.contains(n \@ "ID") =>
         NodeSeq.Empty
+      case Elem("foxml", "contentDigest", _, _, _*) if !plainCopy.contains(n \@ "ID") =>
+        NodeSeq.Empty
       case Elem("dc", "identifier", _, _, _*) if hasDatasetNamespace(n) =>
         NodeSeq.Empty
       case Elem("foxml", "digitalObject", attrs, scope, children @ _*) =>


### PR DESCRIPTION
hello testers: @ekoi @PaulBoon
cc @janvanmansum 

With this fix ingest succeeds, you will need a subsequent update-solar to see it in search results. But examining the dataset directly with for example `http://deasy.dans.knaw.nl:8080/ui/datasets/id/easy-dataset:2` results in an internal error. You could try to help hunt down the problem.
