### PR TITLE
still left fedora-ids in fo.xml of download history

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ the program terminates with an error.
 
 Objects belonging to the dataset are selectied via the relation `isSubordinateTo`.
 For each digital object the last version of each (managed) datastream, a `fo.xml` and `cfg.json` file are downloaded.
-The `fo.xml` file includes the inline datastreams `DC`, `EMD`, `AMD`, `PRSQL`, `DMD` as far as they are present. As
-for the other datastreams:
+The `fo.xml` file includes the inline datastreams `DC`, `EMD`, `AMD`, `PRSQL`, `DMD`, `EASY_FILE_METADATA` and
+`EASY_ITEM_CONTAINER_MD` as far as they are present. As for the other datastreams:
 
 * The datastream `AUDIT` is skipped completely.
 * `RELS-EXT` is exported into to the "relations"-map in the file `cfg.json` ([Digital Object Configuration])

--- a/README.md
+++ b/README.md
@@ -20,19 +20,14 @@ the program terminates with an error.
 
 Objects belonging to the dataset are selectied via the relation `isSubordinateTo`.
 For each digital object the last version of each (managed) datastream, a `fo.xml` and `cfg.json` file are downloaded.
-The `fo.xml` file includes the inline datastreams `DC`, `EMD`, `AMD`, `PRSQL`, `DMD`, `EASY_FILE_METADATA` and
-`EASY_ITEM_CONTAINER_MD` as far as they are present. As for the other datastreams:
-
-* The datastream `AUDIT` is skipped completely.
-* `RELS-EXT` is exported into to the "relations"-map in the file `cfg.json` ([Digital Object Configuration])
-  Fedora PIDs that reference downloaded objects are replaced by the appropriate SDO-name.
-* Other datastreams, such as `EASY_FILE_METADATA`,  are downloaded separately regardless whether they are inline or
-  managed.
+The `fo.xml` file includes the inline datastreams except `RELS_EXT`
+which is exported into to the "relations"-map in the file `cfg.json` ([Digital Object Configuration]).
+Fedora PIDs in this file that reference downloaded objects are replaced by the appropriate SDO-name.
 
 Checksums and PIDs of downloaded objects are removed from the downloaded `fo.xml`.
 For that purpose the following components are removed:
 
-* The elements `<dc:idientifier>` and `<sid>` if their content starts with `easy-dataset:`, `easy-file:`, `easy-folder:` or `dans-jumpoff:`
+* Any element who's content equals the id of one of the downloaded objects,
 * The attribute PID in the element `<foxml:digitalObject>`
 * The attribute DIGEST in the element `<foxml:contentDigest>`
 

--- a/src/main/scala/nl/knaw/dans/easy/export/EasyExportDataset.scala
+++ b/src/main/scala/nl/knaw/dans/easy/export/EasyExportDataset.scala
@@ -56,7 +56,7 @@ class EasyExportDataset(s: Settings) {
       foxmlContent        = strip(foXml, allIds)
       _                  <- verifyFedoraIds(foxmlContent, allIds, "fo.xml")
       _                  <- new File(sdoDir, "fo.xml").safeWrite(foxmlContent)
-      _                   = warnForUserIds(foXml)
+      _                   = for (maybeUserId <- getUserIds(foXml)) log.warn(s"fo.xml contains $maybeUserId")
     } yield foXml
   }
 

--- a/src/main/scala/nl/knaw/dans/easy/export/EasyExportDataset.scala
+++ b/src/main/scala/nl/knaw/dans/easy/export/EasyExportDataset.scala
@@ -18,31 +18,31 @@ package nl.knaw.dans.easy.export
 
 import java.io.File
 
-import nl.knaw.dans.easy.export.FOXML.strip
+import nl.knaw.dans.easy.export.EasyExportDataset._
+import nl.knaw.dans.easy.export.FOXML.{warnForUserIds, strip}
 import org.slf4j.LoggerFactory
 
 import scala.util.{Failure, Success, Try}
-import scala.xml.{Elem, Node}
+import scala.xml.Node
 
 class EasyExportDataset(s: Settings) {
 
   def run(): Try[Seq[String]] = {
-    EasyExportDataset.log.info(s.toString)
+    log.info(s.toString)
     for {
       _      <- Try(s.sdoSet.mkdirs())
       subIds <- s.fedora.getSubordinates(s.datasetId)
       allIds  = s.datasetId +: subIds
-      _      <- subIds.foreachUntilFailure((id: String) => exportObject(id,allIds))
+      _      <- subIds.foreachUntilFailure(exportObject(_,allIds))
       foXML  <- exportObject(s.datasetId, allIds)
     } yield allIds
   }
-
 
   private def exportObject(objectId: String,
                            allIds: Seq[String]
                           ): Try[Node] = {
     val sdoDir = new File(s.sdoSet,toSdoName(objectId))
-    EasyExportDataset.log.info(s"exporting $objectId to $sdoDir")
+    log.info(s"exporting $objectId to $sdoDir")
     for {
       foXmlInputStream   <- s.fedora.getFoXml(objectId)
       foXml              <- foXmlInputStream.readXmlAndClose
@@ -50,12 +50,13 @@ class EasyExportDataset(s: Settings) {
       relsExtXml         <- getRelsExt(foXml)
       jsonContent        <- JSON(sdoDir, datastreams, relsExtXml , placeHoldersFor = allIds)
       _                  <- Try(sdoDir.mkdir())
-      _                  <- datastreams.foreachUntilFailure((ds: Node) => exportDatastream(objectId, sdoDir, ds))
-      _                  <- verifyIds(jsonContent, allIds, "cfg.json")
+      _                  <- datastreams.foreachUntilFailure(exportDatastream(objectId, sdoDir, _))
+      _                  <- verifyFedoraIds(jsonContent, allIds, "cfg.json")
       _                  <- new File(sdoDir, "cfg.json").safeWrite(jsonContent)
       foxmlContent        = strip(foXml)
-      _                  <- verifyIds(foxmlContent, allIds, "fo.xml")
+      _                  <- verifyFedoraIds(foxmlContent, allIds, "fo.xml")
       _                  <- new File(sdoDir, "fo.xml").safeWrite(foxmlContent)
+      _                   = warnForUserIds(foXml)
     } yield foXml
   }
 
@@ -66,7 +67,7 @@ class EasyExportDataset(s: Settings) {
     for {
       dsID       <- Try(ds \@ "ID")
       exportFile = new File(sdoDir, dsID)
-      _          = EasyExportDataset.log.info(s"exporting datastream $dsID to $exportFile")
+      _          = log.info(s"exporting datastream $dsID to $exportFile")
       is         <- s.fedora.disseminateDatastream(objectId, dsID)
       _          <- is.copyAndClose(exportFile)
     // TODO histories of versionable datastreams such as (additional) licenses?
@@ -74,9 +75,13 @@ class EasyExportDataset(s: Settings) {
   }
 
   /** On the flight verification of a proper implementation.
-    * Errors might occur when trying to export something else than a dataset. */
-  def verifyIds(content: String, allIds: Seq[String], fileName :String): Try[Unit] =
-    allIds.foreachUntilFailure((id: String) => // "$id"
+    * Errors might occur when trying to export something else than a dataset.
+    * A proper implementation means none of the downloaded ids in any fo.xml or cfg.json
+    * Not quoted IDs are accepted, as for example a relation with
+    * "oai:easy.dans.knaw.nl:easy-dataset:300".
+    * */
+  def verifyFedoraIds(content: String, allIds: Seq[String], fileName :String): Try[Unit] =
+    allIds.foreachUntilFailure(id =>
       if (content.contains(s">$id<") || content.contains(s""""$id""""))
         Failure(new Exception(s"$fileName contains a downloaded ID $id\n$content"))
       else Success(Unit)

--- a/src/main/scala/nl/knaw/dans/easy/export/FOXML.scala
+++ b/src/main/scala/nl/knaw/dans/easy/export/FOXML.scala
@@ -32,7 +32,7 @@ object FOXML {
     *   these IDs should be identical between EASY-fedora instances
     *   unless a release that changed audiences was not applied everywhere
     */
-  val downloadInFoxml = Seq("DC", "EMD", "AMD", "PRSQL", "DMD")
+  val downloadInFoxml = Seq("DC", "EMD", "AMD", "PRSQL", "DMD", "EASY_FILE_METADATA", "EASY_ITEM_CONTAINER_MD")
 
   /** labels of XML elements that contain user IDs, e.g: <depositorId>someone</depositorId> */
   val userLabels = Set("user-id", "depositorId", "doneById", "requesterId")
@@ -49,6 +49,14 @@ object FOXML {
         NodeSeq.Empty
       case Elem("foxml", "digitalObject", attrs, scope, children @ _*) =>
         Elem("foxml", "digitalObject", attrs.remove("PID"), scope, minimizeEmpty=false, children: _*)
+
+      // obsolete content of FILE_ITEM_METADATA with fedora ids, they might not have been cleaned up
+      case Elem(_, "parentSid", _, _, _*) =>
+        NodeSeq.Empty
+      case Elem(_, "datasetSid", _, _, _*) =>
+        NodeSeq.Empty
+
+      // skip cheksum as we might have altered the content in the cases above
       case Elem("foxml", "contentDigest", attrs, scope, children @ _*) =>
         Elem("foxml", "contentDigest", attrs.remove("DIGEST"), scope, minimizeEmpty=false, children: _*)
 


### PR DESCRIPTION
@DANS-KNAW/easy 

The application now has hardly any knowledge about datasets any more. Just:
- the isSubordinate relation to find other objects to download than the specified fedora-id
- which elements/attributes in fo.xml contain user ids to generate warnings

I guess neither would cause problems if you tried to export anything else than a dataset from even a non-easy fedora instance. Nice side effect of making the code simple, robust and reduce maintenance risks.
