### PR TITLE
fixed checking description in README.md and pom.xml

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/export/Conf.scala
+++ b/src/main/scala/nl/knaw/dans/easy/export/Conf.scala
@@ -33,11 +33,11 @@ class Conf (args: Seq[String]) extends ScallopConf(args) {
 
   version(s"$printedName v${Version()}")
   banner(s"""
-            |$description
+            |  $description
             |
             |Usage:
             |
-            | $synopsis
+            |  $synopsis
             |
             |Options:
             |""".stripMargin)

--- a/src/main/scala/nl/knaw/dans/easy/export/Conf.scala
+++ b/src/main/scala/nl/knaw/dans/easy/export/Conf.scala
@@ -21,20 +21,23 @@ import java.net.URL
 import org.rogach.scallop._
 import org.slf4j.LoggerFactory
 
-class Conf private (args: Seq[String]) extends ScallopConf(args) {
+class Conf (args: Seq[String]) extends ScallopConf(args) {
   val log = LoggerFactory.getLogger(getClass)
 
   appendDefaultToDescription = true
   editBuilder(_.setHelpWidth(110))
 
   printedName = "easy-export-dataset"
+  val description = """Export an EASY dataset to a Staged Digital Object set."""
+  val synopsis = s"""$printedName <dataset-pid> <staged-digital-object-set>"""
+
   version(s"$printedName v${Version()}")
   banner(s"""
-            |Export an EASY dataset to a Staged Digital Object set.
+            |$description
             |
             |Usage:
             |
-            | $printedName <dataset-pid> <staged-digital-object-set>
+            | $synopsis
             |
             |Options:
             |""".stripMargin)

--- a/src/test/scala/nl/knaw/dans/easy/export/ConfSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/export/ConfSpec.scala
@@ -25,32 +25,38 @@ import scala.collection.JavaConverters._
 
 class ConfSpec extends FlatSpec with Matchers {
 
-  val helpInfo = {
+  private val clo = new Conf(Array[String]()) {
+    // avoids System.exit() in case of invalid arguments or "--help"
+    override def verify(): Unit = {}
+  }
+
+  private val helpInfo = {
     val mockedStdOut = new ByteArrayOutputStream()
     Console.withOut(mockedStdOut) {
-      Conf.dummyInstance.printHelp()
+      clo.printHelp()
     }
     mockedStdOut.toString
   }
 
-  "first banner line" should "be part of README.md and pom.xml" in {
-    val description = helpInfo.split("\n")(1)
-    new File("README.md") should containTrimmed(description)
-    new File("pom.xml") should containTrimmed(description)
-  }
-
   "options in help info" should "be part of README.md" in {
-    val options = helpInfo.split("Options:")(1)
+    val lineSeparators = s"(${System.lineSeparator()})+"
+    val options = helpInfo.split(s"${lineSeparators}Options:$lineSeparators")(1)
+    options.trim.length shouldNot be (0)
     new File("README.md") should containTrimmed(options)
   }
 
   "synopsis in help info" should "be part of README.md" in {
-    val synopsis = helpInfo.split("Options:")(0).split("Usage:")(1)
-    new File("README.md") should containTrimmed(synopsis)
+    new File("README.md") should containTrimmed(clo.synopsis)
+  }
+
+  "description line(s) in help info" should "be part of README.md and pom.xml" in {
+    val description = clo.description
+    new File("README.md") should containTrimmed(description)
+    new File("pom.xml") should containTrimmed(description)
   }
 
   "distributed default properties" should "be valid options" in {
-    val optKeys = Conf.dummyInstance.builder.opts.map(opt => opt.name).toArray
+    val optKeys = clo.builder.opts.map(opt => opt.name).toArray
     val propKeys = new PropertiesConfiguration("src/main/assembly/dist/cfg/application.properties")
       .getKeys.asScala.withFilter(key => key.startsWith("default.") )
 

--- a/src/test/scala/nl/knaw/dans/easy/export/ConfSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/export/ConfSpec.scala
@@ -50,9 +50,8 @@ class ConfSpec extends FlatSpec with Matchers {
   }
 
   "description line(s) in help info" should "be part of README.md and pom.xml" in {
-    val description = clo.description
-    new File("README.md") should containTrimmed(description)
-    new File("pom.xml") should containTrimmed(description)
+    new File("README.md") should containTrimmed(clo.description)
+    new File("pom.xml") should containTrimmed(clo.description)
   }
 
   "distributed default properties" should "be valid options" in {
@@ -62,5 +61,4 @@ class ConfSpec extends FlatSpec with Matchers {
 
     propKeys.foreach(key => optKeys should contain (key.replace("default.","")) )
   }
-
 }


### PR DESCRIPTION
fixes technical debt

#### When applied it will
* no longer look with an empty string as description in `README.xml` and `pom.xml`
* fixed `--help` for some of the projects
* 

#### Where should the reviewer @DANS-KNAW/easy start?

* extracted `description` and `synopsis` out of the banner for each `ScalopConf` class to simplify testing
* valid options no longer required when overiding `verify()` 
* differences between various projects are caused by different treatment of the configuration though the command line options and/or application.properties

#### How should this be manually tested?

execute `./run.sh --help`

#### related pull requests on github
repo                       | PR | note
-------------------------- | ----------------- | ---
easy-module-archetype | .. | 
easy-ingest | .. | 
easy-stage-dataset | .. |
easy-update-solr-index | .. |
easy-update-metadata-dataset                      | [5](https://github.com/DANS-KNAW/easy-update-metadata-dataset/pull/5) | just commit https://github.com/DANS-KNAW/easy-update-metadata-dataset/pull/5/commits/70125781218a751fdd51d7a4fb9e30152b27d7cf
